### PR TITLE
refactor: データベースサービスの設定管理を改善

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 OPENAI_API_KEY=your_openai_api_key
 UPSTASH_VECTOR_REST_URL=your_upstash_vector_url
 UPSTASH_VECTOR_REST_TOKEN=your_upstash_vector_token
+
+# データファイルパス設定（オプション）
+# 指定しない場合はプロジェクト相対パスが自動設定されます
+# DATA_FILE_PATH=/path/to/your/data.json
+# CONVERTED_DATA_FILE_PATH=/path/to/your/convert_data.json
+# EMBEDDING_FILE_PATH=/path/to/your/embedding_list.jsonl
+# QUERY_DATA_FILE_PATH=/path/to/your/query_data.json

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -8,6 +9,16 @@ class Settings:
     OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY")
     UPSTASH_VECTOR_REST_URL: str = os.getenv("UPSTASH_VECTOR_REST_URL")
     UPSTASH_VECTOR_REST_TOKEN: str = os.getenv("UPSTASH_VECTOR_REST_TOKEN")
+    
+    # プロジェクトルートディレクトリの取得
+    PROJECT_ROOT: Path = Path(__file__).parent.parent.parent.parent
+    
+    # データファイルパス設定
+    DATA_DIR: Path = PROJECT_ROOT / "data"
+    DATA_FILE_PATH: str = os.getenv("DATA_FILE_PATH", str(DATA_DIR / "data.json"))
+    CONVERTED_DATA_FILE_PATH: str = os.getenv("CONVERTED_DATA_FILE_PATH", str(DATA_DIR / "convert_data.json"))
+    EMBEDDING_FILE_PATH: str = os.getenv("EMBEDDING_FILE_PATH", str(DATA_DIR / "embedding_list.jsonl"))
+    QUERY_DATA_FILE_PATH: str = os.getenv("QUERY_DATA_FILE_PATH", str(DATA_DIR / "query_data.json"))
     
     # ベクトル検索設定
     VECTOR_SEARCH_CONFIG = {

--- a/backend/app/services/database_service.py
+++ b/backend/app/services/database_service.py
@@ -1,14 +1,15 @@
 from typing import List, Dict, Any
 import json
 from ..models.rag_models import ContextItem
+from ..core.config import settings
 
 class DatabaseService:
     """通常のデータベース検索サービス（構造化データのフィルタリング）"""
     
     def __init__(self):
-        # データファイルのパスを設定
-        self.data_path = "/Users/masaki/Documents/gamechat-ai/data/data.json"
-        self.converted_data_path = "/Users/masaki/Documents/gamechat-ai/data/convert_data.json"
+        # 設定ファイルからデータファイルのパスを取得
+        self.data_path = settings.DATA_FILE_PATH
+        self.converted_data_path = settings.CONVERTED_DATA_FILE_PATH
         self.cache = None
     
     def _load_data(self) -> List[Dict[str, Any]]:

--- a/docs/scripts/convert_to_format.py
+++ b/docs/scripts/convert_to_format.py
@@ -1,5 +1,12 @@
 import os
 import json
+from pathlib import Path
+from dotenv import load_dotenv
+
+# プロジェクトルートディレクトリを取得
+project_root = Path(__file__).parent.parent
+dotenv_path = project_root / 'backend' / '.env'
+load_dotenv(dotenv_path=dotenv_path)
 
 def convert_to_embedding_format(card_data):
     entries = []
@@ -118,9 +125,9 @@ def convert_to_embedding_format(card_data):
 
 
 if __name__ == "__main__":
-    data_dir = os.path.join(os.path.dirname(__file__), '..', 'data')
-    sample_path = os.path.join(data_dir, 'data.json')
-    out_path = os.path.join(data_dir, 'convert_data.json')
+    # 環境変数からパスを取得、なければデフォルトパスを使用
+    sample_path = os.getenv("DATA_FILE_PATH", str(project_root / 'data' / 'data.json'))
+    out_path = os.getenv("CONVERTED_DATA_FILE_PATH", str(project_root / 'data' / 'convert_data.json'))
 
     with open(sample_path, "r", encoding="utf-8") as f:
         card_list = json.load(f)

--- a/docs/scripts/embedding.py
+++ b/docs/scripts/embedding.py
@@ -2,8 +2,11 @@ import os
 import json
 import openai
 from dotenv import load_dotenv
+from pathlib import Path
 
-dotenv_path = os.path.join(os.path.dirname(__file__), '..', 'backend', '.env')
+# プロジェクトルートディレクトリを取得
+project_root = Path(__file__).parent.parent
+dotenv_path = project_root / 'backend' / '.env'
 load_dotenv(dotenv_path=dotenv_path)
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
@@ -11,11 +14,12 @@ def build_text(data):
     return data.get('text', '')
 
 def main():
-    data_path = os.path.join(os.path.dirname(__file__), '..', 'data', 'convert_data.json')
+    # 環境変数からパスを取得、なければデフォルトパスを使用
+    data_path = os.getenv("CONVERTED_DATA_FILE_PATH", str(project_root / 'data' / 'convert_data.json'))
+    out_path = os.getenv("EMBEDDING_FILE_PATH", str(project_root / 'data' / 'embedding_list.jsonl'))
+    
     with open(data_path, encoding='utf-8') as f:
         data_list = json.load(f)
-
-    out_path = os.path.join(os.path.dirname(__file__), '..', 'data', 'embedding_list.jsonl')
 
     for data in data_list:
         text = build_text(data)
@@ -29,7 +33,7 @@ def main():
 
         with open(out_path, 'a', encoding='utf-8') as f_out:
             f_out.write(json.dumps({
-                "id": data.get("id"),
+                "id": data.get("id"),  
                 "namespace": data.get("namespace"),
                 "text": text,
                 "embedding": embedding


### PR DESCRIPTION
- ハードコードされたファイルパスを設定ベースに変更
- core/config.pyにDATA_FILE_PATHとCONVERTED_DATA_FILE_PATHを追加
- DatabaseServiceでハードコードパスの代わりにsettings.DATA_FILE_PATHを使用
- .env.exampleにデータファイルパスの環境変数サポートを追加
- 設定可能なパスをサポートするようテストフィクスチャを更新
- デフォルトパスフォールバックで後方互換性を確保

この変更により環境依存のハードコードパスを排除し、設定管理を一元化することで
アプリケーションの移植性とテスト性を向上させました。